### PR TITLE
메모장 수정 후 저장 기능 및 삭제 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.hy0417sage.inotes"
         minSdk 22
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -64,5 +64,8 @@ dependencies {
     //Mockito
     testImplementation "io.mockk:mockk:2.21.0"
     androidTestImplementation "io.mockk:mockk-android:2.21.0"
+
+    //onBackPressedDispatcher https://oguzhanaslann.medium.com/onbackpressed-deprecated-so-what-to-use-92ddd55fc21d
+    implementation "androidx.activity:activity:1.7.0-alpha02"
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,9 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     kotlinOptions {
         jvmTarget = '1.8'
     }
@@ -57,4 +60,9 @@ dependencies {
 
     //ktx
     implementation("androidx.fragment:fragment-ktx:1.5.5")
+
+    //Mockito
+    testImplementation "io.mockk:mockk:2.21.0"
+    androidTestImplementation "io.mockk:mockk-android:2.21.0"
+
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.INotes">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,8 +11,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.INotes">
         <activity
-            android:name=".ANoteActivity"
-            android:exported="false" />
+            android:name=".ANoteActivity"/>
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
@@ -2,16 +2,22 @@ package com.hy0417sage.inotes
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 import com.hy0417sage.inotes.repository.database.NotesDataBase
 import com.hy0417sage.inotes.repository.impl.NotesRepositoryImpl
-import com.hy0417sage.inotes.viewmodel.NotesViewModel
 import com.hy0417sage.inotes.ui.EditANoteFragment
+import com.hy0417sage.inotes.ui.ViewANoteFragment
+import com.hy0417sage.inotes.viewmodel.NotesViewModel
 
 class ANoteActivity : AppCompatActivity() {
+
+    var noteTitle: String? = null
+    var noteMainText: String? = null
 
     private val notesViewModel by viewModels<NotesViewModel> {
         object : ViewModelProvider.Factory {
@@ -24,10 +30,22 @@ class ANoteActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_a_note)
-        if (savedInstanceState == null) {
-            supportFragmentManager.beginTransaction()
+
+        val noteId = intent.getIntExtra("id", -1)
+        noteTitle = intent.getStringExtra("title")
+        noteMainText = intent.getStringExtra("mainText")
+
+        fragmentViewChange(noteId)
+    }
+
+    fun fragmentViewChange(signal: Int){
+        when(signal){
+            -1, EDIT_SIGNAL -> supportFragmentManager.beginTransaction()
                 .replace(R.id.container, EditANoteFragment.newInstance())
-                .commitNow()
+                .commit()
+            else -> supportFragmentManager.beginTransaction()
+                .replace(R.id.container, ViewANoteFragment.newInstance())
+                .commit()
         }
     }
 
@@ -37,6 +55,10 @@ class ANoteActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         super.onBackPressed()
+    }
+
+    companion object {
+        const val EDIT_SIGNAL: Int = 1000000000
     }
 
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
@@ -28,6 +28,7 @@ class ANoteActivity : AppCompatActivity() {
             }
         }
     }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_a_note)
@@ -36,11 +37,11 @@ class ANoteActivity : AppCompatActivity() {
         noteTitle = intent.getStringExtra("title")
         noteMainText = intent.getStringExtra("mainText")
 
-        fragmentViewChange(noteId)
+        fragmentViewChange(signal = noteId)
     }
 
-    fun fragmentViewChange(signal: Int){
-        when(signal){
+    fun fragmentViewChange(signal: Int) {
+        when (signal) {
             -1, EDIT_SIGNAL -> supportFragmentManager.beginTransaction()
                 .replace(R.id.container, EditANoteFragment.newInstance())
                 .commit()
@@ -54,7 +55,7 @@ class ANoteActivity : AppCompatActivity() {
         notesViewModel.insertANote(aNoteEntity)
     }
 
-    fun updateANote(aNoteEntity: ANoteEntity){
+    fun updateANote(aNoteEntity: ANoteEntity) {
         notesViewModel.updateANote(aNoteEntity)
     }
 

--- a/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
@@ -18,6 +18,7 @@ class ANoteActivity : AppCompatActivity() {
 
     var noteTitle: String? = null
     var noteMainText: String? = null
+    var noteId: Int = -1
 
     private val notesViewModel by viewModels<NotesViewModel> {
         object : ViewModelProvider.Factory {
@@ -31,7 +32,7 @@ class ANoteActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_a_note)
 
-        val noteId = intent.getIntExtra("id", -1)
+        noteId = intent.getIntExtra("id", -1)
         noteTitle = intent.getStringExtra("title")
         noteMainText = intent.getStringExtra("mainText")
 
@@ -51,6 +52,10 @@ class ANoteActivity : AppCompatActivity() {
 
     fun insertANote(aNoteEntity: ANoteEntity) {
         notesViewModel.insertANote(aNoteEntity)
+    }
+
+    fun updateANote(aNoteEntity: ANoteEntity){
+        notesViewModel.updateANote(aNoteEntity)
     }
 
     override fun onBackPressed() {

--- a/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
@@ -31,7 +31,9 @@ class ANoteActivity : AppCompatActivity() {
         }
     }
 
-    fun insertANote(aNoteEntity: ANoteEntity) = notesViewModel.insertANote(aNoteEntity)
+    fun insertANote(aNoteEntity: ANoteEntity) {
+        notesViewModel.insertANote(aNoteEntity)
+    }
 
     override fun onBackPressed() {
         super.onBackPressed()

--- a/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ANoteActivity.kt
@@ -1,10 +1,10 @@
 package com.hy0417sage.inotes
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.OnBackPressedDispatcher
 import androidx.activity.viewModels
-import androidx.fragment.app.Fragment
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.hy0417sage.inotes.repository.data.ANoteEntity
@@ -13,6 +13,7 @@ import com.hy0417sage.inotes.repository.impl.NotesRepositoryImpl
 import com.hy0417sage.inotes.ui.EditANoteFragment
 import com.hy0417sage.inotes.ui.ViewANoteFragment
 import com.hy0417sage.inotes.viewmodel.NotesViewModel
+
 
 class ANoteActivity : AppCompatActivity() {
 
@@ -40,6 +41,11 @@ class ANoteActivity : AppCompatActivity() {
         fragmentViewChange(signal = noteId)
     }
 
+    fun changeNote(noteTitle: String, noteMainText: String) {
+        this.noteTitle = noteTitle
+        this.noteMainText = noteMainText
+    }
+
     fun fragmentViewChange(signal: Int) {
         when (signal) {
             -1, EDIT_SIGNAL -> supportFragmentManager.beginTransaction()
@@ -55,12 +61,12 @@ class ANoteActivity : AppCompatActivity() {
         notesViewModel.insertANote(aNoteEntity)
     }
 
-    fun updateANote(aNoteEntity: ANoteEntity) {
-        notesViewModel.updateANote(aNoteEntity)
+    fun deleteANote(aNoteEntity: ANoteEntity) {
+        notesViewModel.deleteANote(aNoteEntity)
     }
 
-    override fun onBackPressed() {
-        super.onBackPressed()
+    fun updateANote(aNoteEntity: ANoteEntity) {
+        notesViewModel.updateANote(aNoteEntity)
     }
 
     companion object {

--- a/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
@@ -42,23 +42,27 @@ class MainActivity : AppCompatActivity() {
             val goANote = Intent(this, ANoteActivity::class.java)
             startActivity(goANote)
         }
-        notesAdapter.setItemClickListener { position ->
-            openDetailPage(notesAdapter.aNotePosition(position))
+
+        notesAdapter.setItemClickListener { aNote ->
+            openDetailPage(aNote)
         }
+
         notesViewModel.wholeNotes().observe(this, Observer { wholeNotes ->
-            notesAdapter.updateNotes(wholeNotes)
+            notesAdapter.submitList(wholeNotes)
         })
     }
 
     private fun recyclerViewInit() {
-        binding.recyclerView.layoutManager = LinearLayoutManager(this)
-        binding.recyclerView.adapter = notesAdapter
-        binding.recyclerView.addItemDecoration(
-            DividerItemDecoration(
-                this,
-                LinearLayoutManager.VERTICAL
+        binding.recyclerView.apply {
+            layoutManager = LinearLayoutManager(this@MainActivity)
+            adapter = notesAdapter
+            addItemDecoration(
+                DividerItemDecoration(
+                    this@MainActivity,
+                    LinearLayoutManager.VERTICAL
+                )
             )
-        )
+        }
     }
 
     private fun openDetailPage(aNoteEntity: ANoteEntity) {

--- a/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : AppCompatActivity() {
         binding.recyclerView.adapter = notesAdapter
         binding.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
 
-        notesViewModel.getWholeNotes().observe(this, Observer { wholeNotes ->
+        notesViewModel.wholeNotes().observe(this, Observer { wholeNotes ->
             notesAdapter.updateNotes(wholeNotes)
         })
     }

--- a/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
@@ -50,10 +50,15 @@ class MainActivity : AppCompatActivity() {
         })
     }
 
-    private fun recyclerViewInit(){
+    private fun recyclerViewInit() {
         binding.recyclerView.layoutManager = LinearLayoutManager(this)
         binding.recyclerView.adapter = notesAdapter
-        binding.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
+        binding.recyclerView.addItemDecoration(
+            DividerItemDecoration(
+                this,
+                LinearLayoutManager.VERTICAL
+            )
+        )
     }
 
     private fun openDetailPage(aNoteEntity: ANoteEntity) {

--- a/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/MainActivity.kt
@@ -3,6 +3,7 @@ package com.hy0417sage.inotes
 import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Observer
@@ -11,6 +12,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.hy0417sage.inotes.databinding.ActivityMainBinding
+import com.hy0417sage.inotes.repository.data.ANoteEntity
 import com.hy0417sage.inotes.repository.database.NotesDataBase
 import com.hy0417sage.inotes.repository.impl.NotesRepositoryImpl
 import com.hy0417sage.inotes.ui.adapter.NotesAdapter
@@ -33,20 +35,33 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
+        recyclerViewInit()
 
-        binding.button.setOnClickListener {
-            val goANoteActivity = Intent(this, ANoteActivity::class.java)
-            startActivity(goANoteActivity)
+        binding.createANoteButton.setOnClickListener {
+            val goANote = Intent(this, ANoteActivity::class.java)
+            startActivity(goANote)
         }
-
-        binding.recyclerView.layoutManager = LinearLayoutManager(this)
-        binding.recyclerView.adapter = notesAdapter
-        binding.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
-
+        notesAdapter.setItemClickListener { position ->
+            openDetailPage(notesAdapter.aNotePosition(position))
+        }
         notesViewModel.wholeNotes().observe(this, Observer { wholeNotes ->
             notesAdapter.updateNotes(wholeNotes)
         })
+    }
+
+    private fun recyclerViewInit(){
+        binding.recyclerView.layoutManager = LinearLayoutManager(this)
+        binding.recyclerView.adapter = notesAdapter
+        binding.recyclerView.addItemDecoration(DividerItemDecoration(this, LinearLayoutManager.VERTICAL))
+    }
+
+    private fun openDetailPage(aNoteEntity: ANoteEntity) {
+        val goANote = Intent(this, ANoteActivity::class.java)
+        goANote.putExtra("id", aNoteEntity.id)
+        goANote.putExtra("title", aNoteEntity.title)
+        goANote.putExtra("mainText", aNoteEntity.mainText)
+        Log.d("MainActivity", "${aNoteEntity.id}, ${aNoteEntity.title}, ${aNoteEntity.mainText}")
+        startActivity(goANote)
     }
 }

--- a/app/src/main/java/com/hy0417sage/inotes/repository/NotesRepository.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/NotesRepository.kt
@@ -6,5 +6,6 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 interface NotesRepository {
     suspend fun insertANote(aNoteEntity: ANoteEntity)
     suspend fun deleteANote(aNoteEntity: ANoteEntity)
+    suspend fun updateANote(aNoteEntity: ANoteEntity)
     fun wholeNotes(): LiveData<List<ANoteEntity>>
 }

--- a/app/src/main/java/com/hy0417sage/inotes/repository/NotesRepository.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/NotesRepository.kt
@@ -6,5 +6,5 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 interface NotesRepository {
     suspend fun insertANote(aNoteEntity: ANoteEntity)
     suspend fun deleteANote(aNoteEntity: ANoteEntity)
-    fun getWholeNotes(): LiveData<List<ANoteEntity>>
+    fun wholeNotes(): LiveData<List<ANoteEntity>>
 }

--- a/app/src/main/java/com/hy0417sage/inotes/repository/database/ANoteDao.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/database/ANoteDao.kt
@@ -11,7 +11,7 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 interface ANoteDao {
 
     @Query("SELECT * FROM ANoteEntity")
-    fun getWholeNotes(): LiveData<List<ANoteEntity>>
+    fun wholeNotes(): LiveData<List<ANoteEntity>>
 
     @Insert
     suspend fun insertANote(aNote: ANoteEntity)

--- a/app/src/main/java/com/hy0417sage/inotes/repository/database/ANoteDao.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/database/ANoteDao.kt
@@ -1,10 +1,7 @@
 package com.hy0417sage.inotes.repository.database
 
 import androidx.lifecycle.LiveData
-import androidx.room.Dao
-import androidx.room.Delete
-import androidx.room.Insert
-import androidx.room.Query
+import androidx.room.*
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 
 @Dao
@@ -18,4 +15,7 @@ interface ANoteDao {
 
     @Delete
     suspend fun deleteANote(aNote: ANoteEntity)
+
+    @Update
+    suspend fun updateANote(aNote: ANoteEntity)
 }

--- a/app/src/main/java/com/hy0417sage/inotes/repository/database/NotesDataBase.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/database/NotesDataBase.kt
@@ -11,14 +11,14 @@ abstract class NotesDataBase : RoomDatabase() {
 
     abstract fun getANoteDao(): ANoteDao
 
-    companion object{
+    companion object {
         @Volatile
         private var INSTANCE: NotesDataBase? = null
 
         fun getInstance(
             context: Context
-        ) : NotesDataBase {
-            return INSTANCE ?: synchronized(this){
+        ): NotesDataBase {
+            return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
                     context.applicationContext,
                     NotesDataBase::class.java,

--- a/app/src/main/java/com/hy0417sage/inotes/repository/database/NotesDataBase.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/database/NotesDataBase.kt
@@ -10,8 +10,8 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 abstract class NotesDataBase : RoomDatabase() {
 
     abstract fun getANoteDao(): ANoteDao
-    companion object{
 
+    companion object{
         @Volatile
         private var INSTANCE: NotesDataBase? = null
 

--- a/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
@@ -8,11 +8,11 @@ class NotesRepositoryImpl(private val aNoteDao: ANoteDao) : NotesRepository {
 
     override fun wholeNotes() = aNoteDao.wholeNotes()
 
-    override suspend fun insertANote(aNoteEntity: ANoteEntity){
+    override suspend fun insertANote(aNoteEntity: ANoteEntity) {
         aNoteDao.insertANote(aNoteEntity)
     }
 
-    override suspend fun deleteANote(aNoteEntity: ANoteEntity){
+    override suspend fun deleteANote(aNoteEntity: ANoteEntity) {
         aNoteDao.deleteANote(aNoteEntity)
     }
 

--- a/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
@@ -15,4 +15,8 @@ class NotesRepositoryImpl(private val aNoteDao: ANoteDao) : NotesRepository {
     override suspend fun deleteANote(aNoteEntity: ANoteEntity){
         aNoteDao.deleteANote(aNoteEntity)
     }
+
+    override suspend fun updateANote(aNoteEntity: ANoteEntity) {
+        aNoteDao.updateANote(aNoteEntity)
+    }
 }

--- a/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/repository/impl/NotesRepositoryImpl.kt
@@ -6,7 +6,7 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 
 class NotesRepositoryImpl(private val aNoteDao: ANoteDao) : NotesRepository {
 
-    override fun getWholeNotes() = aNoteDao.getWholeNotes()
+    override fun wholeNotes() = aNoteDao.wholeNotes()
 
     override suspend fun insertANote(aNoteEntity: ANoteEntity){
         aNoteDao.insertANote(aNoteEntity)

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -6,14 +6,15 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import com.hy0417sage.inotes.ANoteActivity
 import com.hy0417sage.inotes.databinding.FragmentEditANoteBinding
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 
 class EditANoteFragment : Fragment() {
 
-    lateinit var aNoteActivity: ANoteActivity
-    lateinit var binding: FragmentEditANoteBinding
+    private lateinit var aNoteActivity: ANoteActivity
+    private lateinit var binding: FragmentEditANoteBinding
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -35,43 +36,48 @@ class EditANoteFragment : Fragment() {
 
     private fun checkNoteExists(id: Int) {
         when (id) {
-            -1 -> insertANote(
-                aNoteEntity = ANoteEntity(
-                    null,
-                    binding.mainTextEdit.text.toString(),
-                    binding.mainTextEdit.text.toString()
-                )
-            )
+            -1 -> insertANote()
             else -> {
+                binding.titleEdit.setText(aNoteActivity.noteTitle.toString())
                 binding.mainTextEdit.setText(aNoteActivity.noteMainText.toString())
-                insertANote(
-                    id = aNoteActivity.noteId, aNoteEntity = ANoteEntity(
-                        aNoteActivity.noteId,
-                        binding.mainTextEdit.text.toString(),
-                        binding.mainTextEdit.text.toString()
-                    )
-                )
+                insertANote(id = aNoteActivity.noteId)
             }
         }
     }
 
-    private fun insertANote(id: Int? = null, aNoteEntity: ANoteEntity) {
-        binding.button.setOnClickListener {
-            when (id) {
-                null -> {
-                    aNoteActivity.insertANote(
-                        aNoteEntity
-                    )
+    private fun insertANote(id: Int? = null) {
+        binding.insertNote.setOnClickListener {
+            val title = binding.titleEdit.text.toString()
+            val mainText = binding.mainTextEdit.text.toString()
+            if (title.isNotEmpty() || mainText.isNotEmpty()) {
+                when (id) {
+                    null -> {
+                        aNoteActivity.insertANote(
+                            aNoteEntity(id, title, mainText)
+                        )
+                        aNoteActivity.onBackPressedDispatcher.onBackPressed()
+                    }
+                    else -> {
+                        aNoteActivity.updateANote(
+                            aNoteEntity(id, title, mainText)
+                        )
+                        aNoteActivity.changeNote(title, mainText)
+                        aNoteActivity.fragmentViewChange(id)
+                    }
                 }
-                else -> {
-                    aNoteActivity.updateANote(
-                        aNoteEntity
-                    )
-                }
-
+            }else{
+                val toast = Toast.makeText(aNoteActivity,"note is empty\n can't save (｡•́︿•̀｡)", Toast.LENGTH_SHORT)
+                toast.show()
             }
-            aNoteActivity.onBackPressed()
         }
+    }
+
+    fun aNoteEntity(id: Int?, title: String, mainText: String): ANoteEntity {
+        return ANoteEntity(
+            id,
+            title,
+            mainText
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -20,7 +20,6 @@ class EditANoteFragment : Fragment() {
         if (context is ANoteActivity) aNoteActivity = context
     }
 
-    //바인딩을 사용했을때 맵핑하는 방법이다.
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -26,6 +26,12 @@ class EditANoteFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         binding = FragmentEditANoteBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
         binding.button.setOnClickListener {
             aNoteActivity.insertANote(
                 ANoteEntity(
@@ -36,11 +42,6 @@ class EditANoteFragment : Fragment() {
             )
             aNoteActivity.onBackPressed()
         }
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
 
     }
 

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -30,40 +30,42 @@ class EditANoteFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
         checkNoteExists(aNoteActivity.noteId)
-
     }
 
-    private fun checkNoteExists(id: Int){
-        when (id){
-            -1 -> insertANote()
+    private fun checkNoteExists(id: Int) {
+        when (id) {
+            -1 -> insertANote(
+                aNoteEntity = ANoteEntity(
+                    null,
+                    binding.mainTextEdit.text.toString(),
+                    binding.mainTextEdit.text.toString()
+                )
+            )
             else -> {
                 binding.mainTextEdit.setText(aNoteActivity.noteMainText.toString())
-                insertANote(id = aNoteActivity.noteId)
+                insertANote(
+                    id = aNoteActivity.noteId, aNoteEntity = ANoteEntity(
+                        aNoteActivity.noteId,
+                        binding.mainTextEdit.text.toString(),
+                        binding.mainTextEdit.text.toString()
+                    )
+                )
             }
         }
     }
 
-    private fun insertANote(id: Int? = null) {
+    private fun insertANote(id: Int? = null, aNoteEntity: ANoteEntity) {
         binding.button.setOnClickListener {
             when (id) {
                 null -> {
                     aNoteActivity.insertANote(
-                        ANoteEntity(
-                            id,
-                            binding.mainTextEdit.text.toString(),
-                            binding.mainTextEdit.text.toString()
-                        )
+                        aNoteEntity
                     )
                 }
                 else -> {
                     aNoteActivity.updateANote(
-                        ANoteEntity(
-                            id,
-                            binding.mainTextEdit.text.toString(),
-                            binding.mainTextEdit.text.toString()
-                        )
+                        aNoteEntity
                     )
                 }
 

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -15,10 +15,6 @@ class EditANoteFragment : Fragment() {
     lateinit var aNoteActivity: ANoteActivity
     lateinit var binding: FragmentEditANoteBinding
 
-    companion object {
-        fun newInstance() = EditANoteFragment()
-    }
-
     override fun onAttach(context: Context) {
         super.onAttach(context)
         if (context is ANoteActivity) aNoteActivity = context
@@ -46,5 +42,9 @@ class EditANoteFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+    }
+
+    companion object {
+        fun newInstance() = EditANoteFragment()
     }
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/EditANoteFragment.kt
@@ -31,17 +31,45 @@ class EditANoteFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        checkNoteExists(aNoteActivity.noteId)
+
+    }
+
+    private fun checkNoteExists(id: Int){
+        when (id){
+            -1 -> insertANote()
+            else -> {
+                binding.mainTextEdit.setText(aNoteActivity.noteMainText.toString())
+                insertANote(id = aNoteActivity.noteId)
+            }
+        }
+    }
+
+    private fun insertANote(id: Int? = null) {
         binding.button.setOnClickListener {
-            aNoteActivity.insertANote(
-                ANoteEntity(
-                    null,
-                    null,
-                    binding.textView.text.toString()
-                )
-            )
+            when (id) {
+                null -> {
+                    aNoteActivity.insertANote(
+                        ANoteEntity(
+                            id,
+                            binding.mainTextEdit.text.toString(),
+                            binding.mainTextEdit.text.toString()
+                        )
+                    )
+                }
+                else -> {
+                    aNoteActivity.updateANote(
+                        ANoteEntity(
+                            id,
+                            binding.mainTextEdit.text.toString(),
+                            binding.mainTextEdit.text.toString()
+                        )
+                    )
+                }
+
+            }
             aNoteActivity.onBackPressed()
         }
-
     }
 
     companion object {

--- a/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
@@ -1,32 +1,48 @@
 package com.hy0417sage.inotes.ui
 
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import com.hy0417sage.inotes.ANoteActivity
 import com.hy0417sage.inotes.R
+import com.hy0417sage.inotes.databinding.FragmentEditANoteBinding
+import com.hy0417sage.inotes.databinding.FragmentViewANoteBinding
+import com.hy0417sage.inotes.repository.data.ANoteEntity
 import com.hy0417sage.inotes.viewmodel.NotesViewModel
 
 class ViewANoteFragment : Fragment() {
 
-    private lateinit var viewModel: NotesViewModel
+    lateinit var aNoteActivity: ANoteActivity
+    private lateinit var binding: FragmentViewANoteBinding
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        if (context is ANoteActivity) aNoteActivity = context
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View {
-        return inflater.inflate(R.layout.fragment_view_a_note, container, false)
+    ): View? {
+        binding = FragmentViewANoteBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-//        viewModel = ViewModelProvider(this).get(NotesViewModel::class.java)
-//        // TODO: Use the ViewModel
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.aNoteTitle.text = aNoteActivity.noteTitle.toString()
+        binding.aNoteMainText.text = aNoteActivity.noteMainText.toString()
+        binding.viewANote.setOnClickListener {
+            aNoteActivity.fragmentViewChange(Companion.EDIT_SIGNAL)
+        }
     }
 
     companion object {
         fun newInstance() = ViewANoteFragment()
+        const val EDIT_SIGNAL: Int = 1000000000
     }
 
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
@@ -15,7 +15,7 @@ import com.hy0417sage.inotes.viewmodel.NotesViewModel
 
 class ViewANoteFragment : Fragment() {
 
-    lateinit var aNoteActivity: ANoteActivity
+    private lateinit var aNoteActivity: ANoteActivity
     private lateinit var binding: FragmentViewANoteBinding
 
     override fun onAttach(context: Context) {
@@ -37,6 +37,21 @@ class ViewANoteFragment : Fragment() {
         binding.aNoteMainText.text = aNoteActivity.noteMainText.toString()
         binding.viewANote.setOnClickListener {
             aNoteActivity.fragmentViewChange(Companion.EDIT_SIGNAL)
+        }
+
+        canDeleteANote()
+    }
+
+    private fun canDeleteANote() {
+        binding.deleteButton.setOnClickListener {
+            aNoteActivity.deleteANote(
+                ANoteEntity(
+                    id = aNoteActivity.noteId,
+                    title = aNoteActivity.noteTitle,
+                    mainText = aNoteActivity.noteMainText
+                )
+            )
+            aNoteActivity.onBackPressedDispatcher.onBackPressed()
         }
     }
 

--- a/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/ViewANoteFragment.kt
@@ -10,10 +10,6 @@ import com.hy0417sage.inotes.viewmodel.NotesViewModel
 
 class ViewANoteFragment : Fragment() {
 
-    companion object {
-        fun newInstance() = ViewANoteFragment()
-    }
-
     private lateinit var viewModel: NotesViewModel
 
     override fun onCreateView(
@@ -27,6 +23,10 @@ class ViewANoteFragment : Fragment() {
         super.onActivityCreated(savedInstanceState)
 //        viewModel = ViewModelProvider(this).get(NotesViewModel::class.java)
 //        // TODO: Use the ViewModel
+    }
+
+    companion object {
+        fun newInstance() = ViewANoteFragment()
     }
 
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
@@ -13,7 +13,7 @@ class NotesAdapter :
     private var itemClickListener: OnItemClickListener? = null
 
     class ViewHolder(binding: LayoutANoteBinding) : RecyclerView.ViewHolder(binding.root) {
-        val mainText = binding.mainText
+        val title = binding.titleText
     }
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
@@ -24,8 +24,13 @@ class NotesAdapter :
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val notesList = notesList?.get(position)
-        holder.mainText.text = notesList?.mainText
+        val notesList = notesList.get(position)
+
+        if (notesList.title!!.isEmpty()){
+            holder.title.text = notesList.mainText
+        }else{
+            holder.title.text = notesList.title
+        }
 
         holder.itemView.setOnClickListener {
             itemClickListener?.onClick(position)

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
@@ -10,6 +10,7 @@ class NotesAdapter :
     RecyclerView.Adapter<NotesAdapter.ViewHolder>(){
 
     private var notesList: List<ANoteEntity> = ArrayList()
+    private var itemClickListener: OnItemClickListener? = null
 
     class ViewHolder(binding: LayoutANoteBinding) : RecyclerView.ViewHolder(binding.root) {
         val mainText = binding.mainText
@@ -25,6 +26,10 @@ class NotesAdapter :
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val notesList = notesList?.get(position)
         holder.mainText.text = notesList?.mainText
+
+        holder.itemView.setOnClickListener{
+            itemClickListener?.onClick(position)
+        }
     }
 
     override fun getItemCount() = notesList.size
@@ -33,4 +38,14 @@ class NotesAdapter :
         this.notesList = notesList
         notifyDataSetChanged()
     }
+
+    fun interface OnItemClickListener {
+        fun onClick(position: Int)
+    }
+
+    fun setItemClickListener(onItemClickListener: OnItemClickListener) {
+        this.itemClickListener = onItemClickListener
+    }
+
+    fun aNotePosition(position: Int) = notesList[position]
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
@@ -7,7 +7,7 @@ import com.hy0417sage.inotes.databinding.LayoutANoteBinding
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 
 class NotesAdapter :
-    RecyclerView.Adapter<NotesAdapter.ViewHolder>(){
+    RecyclerView.Adapter<NotesAdapter.ViewHolder>() {
 
     private var notesList: List<ANoteEntity> = ArrayList()
     private var itemClickListener: OnItemClickListener? = null
@@ -27,7 +27,7 @@ class NotesAdapter :
         val notesList = notesList?.get(position)
         holder.mainText.text = notesList?.mainText
 
-        holder.itemView.setOnClickListener{
+        holder.itemView.setOnClickListener {
             itemClickListener?.onClick(position)
         }
     }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesAdapter.kt
@@ -2,55 +2,40 @@ package com.hy0417sage.inotes.ui.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hy0417sage.inotes.databinding.LayoutANoteBinding
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 
-class NotesAdapter :
-    RecyclerView.Adapter<NotesAdapter.ViewHolder>() {
+class NotesAdapter : ListAdapter<ANoteEntity, RecyclerView.ViewHolder>(NotesDiffCallback()) {
 
-    private var notesList: List<ANoteEntity> = ArrayList()
-    private var itemClickListener: OnItemClickListener? = null
+    private lateinit var itemClickListener: OnItemClickListener
 
-    class ViewHolder(binding: LayoutANoteBinding) : RecyclerView.ViewHolder(binding.root) {
-        val title = binding.titleText
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return NotesViewHolder(
+            LayoutANoteBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
     }
 
-    override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ViewHolder {
-        val binding: LayoutANoteBinding =
-            LayoutANoteBinding.inflate(LayoutInflater.from(viewGroup.context), viewGroup, false)
-
-        return ViewHolder(binding)
-    }
-
-    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val notesList = notesList.get(position)
-
-        if (notesList.title!!.isEmpty()){
-            holder.title.text = notesList.mainText
-        }else{
-            holder.title.text = notesList.title
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        if (holder is NotesViewHolder) {
+            val aNote = getItem(position) as ANoteEntity
+            holder.bind(aNote)
+            holder.itemView.setOnClickListener {
+                itemClickListener?.onClick(aNote)
+            }
         }
-
-        holder.itemView.setOnClickListener {
-            itemClickListener?.onClick(position)
-        }
-    }
-
-    override fun getItemCount() = notesList.size
-
-    fun updateNotes(notesList: List<ANoteEntity>) {
-        this.notesList = notesList
-        notifyDataSetChanged()
     }
 
     fun interface OnItemClickListener {
-        fun onClick(position: Int)
+        fun onClick(aNote: ANoteEntity)
     }
 
     fun setItemClickListener(onItemClickListener: OnItemClickListener) {
         this.itemClickListener = onItemClickListener
     }
-
-    fun aNotePosition(position: Int) = notesList[position]
 }

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesDiffCallback.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesDiffCallback.kt
@@ -1,0 +1,15 @@
+package com.hy0417sage.inotes.ui.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.hy0417sage.inotes.repository.data.ANoteEntity
+
+class NotesDiffCallback : DiffUtil.ItemCallback<ANoteEntity>() {
+
+    override fun areItemsTheSame(oldItem: ANoteEntity, newItem: ANoteEntity): Boolean {
+        return oldItem.hashCode() == newItem.hashCode()
+    }
+
+    override fun areContentsTheSame(oldItem: ANoteEntity, newItem: ANoteEntity): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesViewHolder.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/ui/adapter/NotesViewHolder.kt
@@ -1,0 +1,20 @@
+package com.hy0417sage.inotes.ui.adapter
+
+import androidx.recyclerview.widget.RecyclerView
+import com.hy0417sage.inotes.databinding.LayoutANoteBinding
+import com.hy0417sage.inotes.repository.data.ANoteEntity
+
+class NotesViewHolder(private val binding: LayoutANoteBinding) :
+    RecyclerView.ViewHolder(binding.root) {
+
+    fun bind(aNote: ANoteEntity) {
+        with(binding) {
+            titleText.text = aNote.mainText
+            if (aNote.title!!.isEmpty()) {
+                titleText.text = aNote.mainText
+            } else {
+                titleText.text = aNote.title
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.launch
 
 class NotesViewModel(private val notesRepository : NotesRepositoryImpl) : ViewModel() {
 
-    fun getWholeNotes() = notesRepository.getWholeNotes()
+    fun wholeNotes() = notesRepository.wholeNotes()
 
     fun insertANote(aNoteEntity: ANoteEntity){
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
@@ -22,4 +22,10 @@ class NotesViewModel(private val notesRepository : NotesRepository) : ViewModel(
             notesRepository.deleteANote(aNoteEntity)
         }
     }
+
+    fun updateANote(aNoteEntity: ANoteEntity){
+        viewModelScope.launch(Dispatchers.IO){
+            notesRepository.updateANote(aNoteEntity)
+        }
+    }
 }

--- a/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
@@ -7,24 +7,24 @@ import com.hy0417sage.inotes.repository.data.ANoteEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class NotesViewModel(private val notesRepository : NotesRepository) : ViewModel() {
+class NotesViewModel(private val notesRepository: NotesRepository) : ViewModel() {
 
     fun wholeNotes() = notesRepository.wholeNotes()
 
-    fun insertANote(aNoteEntity: ANoteEntity){
+    fun insertANote(aNoteEntity: ANoteEntity) {
         viewModelScope.launch(Dispatchers.IO) {
             notesRepository.insertANote(aNoteEntity)
         }
     }
 
-    fun deleteANote(aNoteEntity: ANoteEntity){
+    fun deleteANote(aNoteEntity: ANoteEntity) {
         viewModelScope.launch(Dispatchers.IO) {
             notesRepository.deleteANote(aNoteEntity)
         }
     }
 
-    fun updateANote(aNoteEntity: ANoteEntity){
-        viewModelScope.launch(Dispatchers.IO){
+    fun updateANote(aNoteEntity: ANoteEntity) {
+        viewModelScope.launch(Dispatchers.IO) {
             notesRepository.updateANote(aNoteEntity)
         }
     }

--- a/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
+++ b/app/src/main/java/com/hy0417sage/inotes/viewmodel/NotesViewModel.kt
@@ -2,12 +2,12 @@ package com.hy0417sage.inotes.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hy0417sage.inotes.repository.impl.NotesRepositoryImpl
+import com.hy0417sage.inotes.repository.NotesRepository
 import com.hy0417sage.inotes.repository.data.ANoteEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class NotesViewModel(private val notesRepository : NotesRepositoryImpl) : ViewModel() {
+class NotesViewModel(private val notesRepository : NotesRepository) : ViewModel() {
 
     fun wholeNotes() = notesRepository.wholeNotes()
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -10,7 +10,7 @@
         tools:context=".MainActivity">
 
         <Button
-            android:id="@+id/button"
+            android:id="@+id/create_a_note_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/create"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -19,7 +19,7 @@
             app:layout_constraintStart_toStartOf="parent" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerView"
+            android:id="@+id/recycler_view"
             android:layout_width="409dp"
             android:layout_height="681dp"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_edit_a_note.xml
+++ b/app/src/main/res/layout/fragment_edit_a_note.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <EditText
-        android:id="@+id/textView"
+        android:id="@+id/mainTextEdit"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:gravity="top|left"

--- a/app/src/main/res/layout/fragment_edit_a_note.xml
+++ b/app/src/main/res/layout/fragment_edit_a_note.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent" />
 
     <EditText
-        android:id="@+id/mainTextEdit"
+        android:id="@+id/main_text_edit"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:gravity="top|left"

--- a/app/src/main/res/layout/fragment_edit_a_note.xml
+++ b/app/src/main/res/layout/fragment_edit_a_note.xml
@@ -7,25 +7,48 @@
     android:layout_height="match_parent"
     tools:context=".ui.EditANoteFragment">
 
-    <Button
-        android:id="@+id/button"
-        android:layout_width="wrap_content"
+    <EditText
+        android:id="@+id/title_edit"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Button"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_margin="16dp"
+        android:background="@null"
+        android:maxLines="2"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="2dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:background="#0f0f0f0f"
+        app:layout_constraintBottom_toTopOf="@+id/main_text_edit"
+        app:layout_constraintTop_toBottomOf="@+id/title_edit" />
 
     <EditText
         android:id="@+id/main_text_edit"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_margin="16dp"
+        android:background="@null"
         android:gravity="top|left"
         android:inputType="text|textMultiLine"
         android:lines="20"
         android:scrollbars="vertical"
-        app:layout_constraintBottom_toTopOf="@+id/button"
+        app:layout_constraintBottom_toTopOf="@+id/insert_note"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@+id/title_edit" />
+
+    <Button
+        android:id="@+id/insert_note"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/insert_note"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_view_a_note.xml
+++ b/app/src/main/res/layout/fragment_view_a_note.xml
@@ -1,14 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/view_a_note"
     tools:context=".ui.ViewANoteFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
+        android:id="@+id/a_note_title"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-</FrameLayout>
+    <TextView
+        android:id="@+id/a_note_main_text"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_margin="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/a_note_title" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_view_a_note.xml
+++ b/app/src/main/res/layout/fragment_view_a_note.xml
@@ -21,9 +21,18 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_margin="16dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/delete_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/a_note_title" />
+
+    <Button
+        android:id="@+id/delete_button"
+        android:layout_width="wrap_content"
+        android:text="@string/delete"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_a_note.xml
+++ b/app/src/main/res/layout/layout_a_note.xml
@@ -9,6 +9,7 @@
         android:id="@+id/mainText"
         android:layout_width="0dp"
         android:layout_height="47dp"
+        android:layout_margin="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/layout/layout_a_note.xml
+++ b/app/src/main/res/layout/layout_a_note.xml
@@ -6,7 +6,7 @@
     android:layout_height="wrap_content">
 
     <TextView
-        android:id="@+id/mainText"
+        android:id="@+id/main_text"
         android:layout_width="0dp"
         android:layout_height="47dp"
         android:layout_margin="16dp"

--- a/app/src/main/res/layout/layout_a_note.xml
+++ b/app/src/main/res/layout/layout_a_note.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
     <TextView
-        android:id="@+id/main_text"
+        android:id="@+id/title_text"
         android:layout_width="0dp"
         android:layout_height="47dp"
         android:layout_margin="16dp"
+        android:ellipsize="start"
+        android:maxLines="2"
+        android:textStyle="bold"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,8 @@
     <string name="hello_first_fragment">Hello first fragment</string>
     <string name="hello_second_fragment">Hello second fragment. Arg: %1$s</string>
     <string name="create">create</string>
+    <string name="delete">delete</string>
+    <string name="title_hint">제목</string>
+    <string name="main_text_hint">본문</string>
+    <string name="insert_note">insert note</string>
 </resources>


### PR DESCRIPTION
## develop
### [메모 수정 후 저장 기능 추가](https://github.com/f-lab-edu/iNotes/commit/86bfdb455a34b73b69e23e1dcd8145198b0a855b)
- [기존 메모 확인 기능 및 화면 전환 로직 작성](https://github.com/f-lab-edu/iNotes/commit/3f11ee94c6502e7db5b4931a00314d29db217534)
- 저장된 메모 데이터 Entitiy를 명시적 Intent 전달 (MainActivity -> ANoteActivity)
- ANoteActivity에 값이 전달 되었는지의 여부 확인 후 표출해야 하는 화면 지정

## update
### [targetSdk 32 -> 33 로 업데이트](https://github.com/f-lab-edu/iNotes/commit/75e4a3e5c0c3b7ec82109f57a66c450411fd2c74)
- targetSdk 업데이트 
- 뒤로가기 수정 (onbackpressed() -> onBackPressedDispatcher)
### [ListAdapter 적용](https://github.com/f-lab-edu/iNotes/commit/606fbeea72ac9ce9e48913d521a4e39163d5728a)
1. NotesDiffUtilCallback 클래스 추가
2. NotesViewHolder 클래스 추가
### [프레그먼트 UI 수정](https://github.com/f-lab-edu/iNotes/commit/75e4a3e5c0c3b7ec82109f57a66c450411fd2c74)

